### PR TITLE
hardcoding host or port not needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
 </head>
 <body>
   <div id="root" style="height: 100%"></div>
-  <script type="text/javascript" src="http://localhost:8080/bundle.js" charset="utf-8"></script>
+  <script type="text/javascript" src="bundle.js" charset="utf-8"></script>
 </body>
 </html>


### PR DESCRIPTION
No need to hardcode the host or port. Browsers will default to the currently connected host.

So if you need to change the server with: `webpack-dev-server --port 3000`, you don't need to modify the code.
